### PR TITLE
Fix API URL to include /v1 version prefix

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: '/api'
+  apiUrl: '/api/v1'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8080'
+  apiUrl: 'http://localhost:8080/v1'
 };


### PR DESCRIPTION
## Summary
- Add `/v1` prefix to API base URL in development environment (`http://localhost:8080/v1`)
- Add `/v1` prefix to API base URL in production environment (`/api/v1`)
- Ensures API calls use correct versioned endpoints like `/v1/notes`

## Test plan
- [ ] Verify API calls in dev mode go to `http://localhost:8080/v1/notes`
- [ ] Verify production build uses `/api/v1/notes` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)